### PR TITLE
Move distinct to separate parameter, revert how aliases work

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ This file object cannot be overwritten or changed with a simple set action (i.e.
 ### Query
 
 ```
-ModelName.query(filter=...,order=...,page_size=,fields=[...],skip_cache=bool)
+ModelName.query(filter=...,order=...,distinct=...,page_size=,fields=[...],skip_cache=bool)
 ```
 
 Returns a Pandas dataframe object
@@ -98,6 +98,7 @@ Returns a Pandas dataframe object
 | fields     | Returns a data set of columns containing the specified field(s)     | query(fields=['field1','field2','field3']) |
 | filter     | Returns a data set containing objects that match the given field(s) | query(filter={'field_name1': 'value1'})    |
 | order      | Returns a data set ordered by the given field(s)                    | query(order='field')                       |
+| distinct   | Remove duplicate rows from the result (defaults to False)           | query(distinct=True)
 | page size  | Limits the data set to specified number of data points              | query(page_size=10)                        |
 | skip_cache | Skip any caching for this request                                   | query(skip_cache=True)                     |
 
@@ -155,15 +156,6 @@ Example Fields Dict/OrderedDict with Renamed Fields
 or
 
 OrderedDict({field1: new_field1_name})
-```
-
-Legacy: List of Fields dicts denoting alias and distinct values within the field
-
-```
-[{field1: {'alias': new_field1_name, 'distinct': True}}]
-```
-
-(Note: This will be deprecated in future versions)
 
 ### Filter
 

--- a/bulk_api_client/model.py
+++ b/bulk_api_client/model.py
@@ -80,26 +80,22 @@ class ModelAPI(object):
 
     def fields_dict_to_list(self, fields_dict):
         """
-        Creates a list of single dict items from a dict. Makes assumption that
-        a non-dict value is an alias. Does not have support for values more
-        complex than being a nested dict (to specify alias or distinct) or
-        single values (string)
+        Creates a list of single dict items from a dict to meet query api
+        specification.
+
+        E.g. converts
+            {"field1": "field1_alias", "field2": "field2_alias"}
+        to
+            [{"field1": "field1_alias"}, {"field2": "field2_alias"}]
 
         Args:
-            fields_dict (dict): dict of fields columns (with alias and/or
-            distinct)
+            fields_dict (dict): dict of fields columns to desired aliases
 
         Returns:
             list of single dicts
 
         """
-        fields_list = []
-        for k, v in fields_dict.items():
-            if any([isinstance(v, d) for d in [dict, OrderedDict]]):
-                fields_list.append({k: v})
-            else:
-                fields_list.append({k: {"alias": v}})
-        return fields_list
+        return [{k: v} for k, v in fields_dict.items()]
 
     def query(
         self,

--- a/bulk_api_client/model.py
+++ b/bulk_api_client/model.py
@@ -102,6 +102,7 @@ class ModelAPI(object):
         fields=None,
         filter=None,
         order=None,
+        distinct=False,
         page_size=None,
         skip_cache=None,
     ):
@@ -114,6 +115,7 @@ class ModelAPI(object):
             filter (str or dict): filter for the filter query; must be a dict
                 or a yaml string representation of a dict
             order (str): order for the order query
+            distinct (bool): whether to remove duplicate rows from the results
             page_size (str): page size for the page_size query; Default: 10,000
             skip_cache (bool): pause global caching for query request
 
@@ -128,6 +130,7 @@ class ModelAPI(object):
             kwargs = {
                 "fields": fields,
                 "filter": filter,
+                "distinct": distinct,
                 "order": order,
                 "page": current_page,
                 "page_size": page_size,
@@ -142,7 +145,13 @@ class ModelAPI(object):
         return pandas.concat(dataframes)
 
     def _query(
-        self, fields=None, filter=None, order=None, page=None, page_size=None
+        self,
+        fields=None,
+        filter=None,
+        order=None,
+        distinct=False,
+        page=None,
+        page_size=None,
     ):
         """Queries to create a Pandas DataFrame for given queryset. The default
         query may be obtained by calling the function, without passing
@@ -153,6 +162,7 @@ class ModelAPI(object):
             filter (str or dict): filter for the filter query; must be a dict
                 or a yaml string representation of a dict
             order (str): order for the order query
+            distinct (bool): whether to remove duplicate rows from the results
             page (str): page number for the page query; Default: 1
             page_size (str): page size for the page_size query; Default: 10,000
 
@@ -186,6 +196,8 @@ class ModelAPI(object):
         if order is not None:
             if not isinstance(order, str):
                 raise TypeError({"detail": "order must be a string"})
+        if not isinstance(distinct, bool):
+            raise TypeError({"detail": "distinct must be a boolean"})
         if page is not None and (not isinstance(page, int) or page <= 0):
             raise TypeError({"detail": "page must be a positive integer"})
         if page is None:
@@ -203,6 +215,7 @@ class ModelAPI(object):
             "fields": fields,
             "filter": filter,
             "order": order,
+            "distinct": distinct,
             "page": page,
             "page_size": page_size,
         }

--- a/bulk_api_client/query_helpers.py
+++ b/bulk_api_client/query_helpers.py
@@ -24,8 +24,7 @@ class Q:
         chain.
 
         Args:
-            self (Q): dict of fields columns (with alias and/or
-            distinct)
+            self: Q object containing fields, filters on fields and operator
             object_on_right (Q): Q object to the right of self within the chain
 
         Returns:

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -70,6 +70,7 @@ def test_model_api_query(model_api):
     test_fields = "- id\n- text"
     test_order = "text"
     test_filter = "key:value"
+    test_distinct = True
     test_page = [1, 2]
     test_page_size = 1
 
@@ -84,12 +85,14 @@ def test_model_api_query(model_api):
             fields=test_fields,
             filter=test_filter,
             order=test_order,
+            distinct=test_distinct,
             page_size=test_page_size,
         )
         fn.assert_called_with(
             fields=test_fields,
             filter=test_filter,
             order=test_order,
+            distinct=test_distinct,
             page=test_page.pop(),
             page_size=test_page_size,
         )
@@ -105,6 +108,7 @@ def test_model_api_query_skip_cache(model_api):
     test_fields = "- id\n- text"
     test_order = "text"
     test_filter = "key:value"
+    test_distinct = True
     test_page = [1, 2]
     test_page_size = 1
 
@@ -120,6 +124,7 @@ def test_model_api_query_skip_cache(model_api):
                 fields=test_fields,
                 filter=test_filter,
                 order=test_order,
+                distinct=test_distinct,
                 page_size=test_page_size,
                 skip_cache=True,
             )
@@ -127,6 +132,7 @@ def test_model_api_query_skip_cache(model_api):
                 fields=test_fields,
                 filter=test_filter,
                 order=test_order,
+                distinct=test_distinct,
                 page=test_page.pop(),
                 page_size=test_page_size,
             )
@@ -148,6 +154,7 @@ def test_model_api_private_query(model_api, filter, fields, expected_fields):
     url = urljoin(urljoin(path, "{}/".format(model_api.model_name)), "query")
     test_fields = fields
     test_order = "text"
+    test_distinct = True
     test_page = 1
     test_page_size = 1
 
@@ -155,6 +162,7 @@ def test_model_api_private_query(model_api, filter, fields, expected_fields):
         "fields": expected_fields,
         "filter": "key: value\n",
         "order": test_order,
+        "distinct": False,
         "page": test_page,
         "page_size": test_page_size,
     }
@@ -190,6 +198,7 @@ def test_model_api_query_request_null_params(model_api):
         "fields": None,
         "filter": None,
         "order": None,
+        "distinct": False,
         "page": 1,
         "page_size": None,
     }
@@ -216,6 +225,7 @@ def test_model_api_query_q_object(model_api):
     q_obj = Q(col1=1) & Q(col2=2)
     test_fields = "- col1\n- col2"
     test_order = "text"
+    test_distinct = True
     test_filter = q_obj
     test_page = [1, 2]
     test_page_size = 1
@@ -224,6 +234,7 @@ def test_model_api_query_q_object(model_api):
         "fields": "- col1\n- col2\n",
         "filter": "and:\n- col1: 1\n- col2: 2\n",
         "order": test_order,
+        "distinct": test_distinct,
         "page": test_page.pop(0),
         "page_size": test_page_size,
     }
@@ -239,6 +250,7 @@ def test_model_api_query_q_object(model_api):
             fields=test_fields,
             filter=test_filter,
             order=test_order,
+            distinct=test_distinct,
             page_size=test_page_size,
         )
         fn.assert_called_with("GET", url, params=params)
@@ -331,6 +343,7 @@ def test_model_api_query_request_fresh_cache(model_api):
         "fields": None,
         "filter": None,
         "order": None,
+        "distinct": False,
         "page": 1,
         "page_size": None,
     }

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -138,22 +138,8 @@ def test_model_api_query_skip_cache(model_api):
     [
         ("key: value", "- id\n- text", "- id\n- text\n"),
         ({"key": "value"}, ["id", "text"], "- id\n- text\n"),
-        ({"key": "value"}, {"field": "name"}, "- field:\n    alias: name\n",),
-        (
-            {"key": "value"},
-            {"field": {"alias": "name"}},
-            "- field:\n    alias: name\n",
-        ),
-        (
-            {"key": "value"},
-            OrderedDict({"field": "name"}),
-            "- field:\n    alias: name\n",
-        ),
-        (
-            {"key": "value"},
-            OrderedDict({"field": {"alias": "name"}}),
-            "- field:\n    alias: name\n",
-        ),
+        ({"key": "value"}, {"field": "name"}, "- field: name\n",),
+        ({"key": "value"}, OrderedDict({"field": "name"}), "- field: name\n",),
     ],
 )
 def test_model_api_private_query(model_api, filter, fields, expected_fields):


### PR DESCRIPTION
This should wait until after the negation operator is merged as my work is simpler to resolve merge conflicts for.

Companion to https://github.com/pivotbio/data_warehouse/pull/1125